### PR TITLE
Fix issue #7 [Parameterize sender "From" email-id during sending email notification]

### DIFF
--- a/src/server.go
+++ b/src/server.go
@@ -6,15 +6,23 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 
 	"gopkg.in/gomail.v2"
 )
 
 type IncomingReq struct {
 	Email string `json:"emailID"`
+	Subject string `json:"subject"`
+	Body string `json:"body"`
 }
 
-var USERNAME, PASSWORD string
+type Response struct {
+	Message string `json:"message"`
+}
+
+var USERNAME, PASSWORD, HOST, PORT, FROM string
+var IPORT int
 
 func handleMail(w http.ResponseWriter, r *http.Request) {
 	// Read body
@@ -35,30 +43,32 @@ func handleMail(w http.ResponseWriter, r *http.Request) {
 
 	log.Println(req.Email)
 
-	output, err := json.Marshal(req)
+	sendMail(req)
+
+	response := Response{}
+	response.Message = "Email has been successfully to " + req.Email
+	
+	output, err := json.Marshal(response)
 	if err != nil {
 		http.Error(w, err.Error(), 500)
 		return
 	}
-
-	sendMail(req)
-
+	
 	w.Header().Set("content-type", "application/json")
 	w.Write(output)
-
 }
 
 func sendMail(req IncomingReq) {
 	msg := gomail.NewMessage()
-	msg.SetHeader("From", "rishi@email.com")
+	msg.SetHeader("From", FROM)
 	msg.SetHeader("To", req.Email)
-	msg.SetHeader("Subject", "Hello!")
-	msg.SetBody("text/html", "Hello <b>Receiver</b>!")
+	msg.SetHeader("Subject", req.Subject)
+	msg.SetBody("text/html", "<b>" + req.Body + "</b>!")
 
-	host := "smtp.mailtrap.io"
-	port := 2525
+	//host := "smtp.mailtrap.io"
+	//port := 2525
 	
-	daemon := gomail.NewDialer(host, port, USERNAME, PASSWORD)
+	daemon := gomail.NewDialer(HOST, IPORT, USERNAME, PASSWORD)
 
 	// Send the email
 	if err := daemon.DialAndSend(msg); err != nil {
@@ -69,10 +79,21 @@ func sendMail(req IncomingReq) {
 func validateAndSetMailCredentials() {
 	USERNAME = os.Getenv("USERNAME")
 	PASSWORD = os.Getenv("PASSWORD")
+	HOST = os.Getenv("HOST")
+	PORT = os.Getenv("PORT")
+	FROM = os.Getenv("FROM")
 	
-	if USERNAME == "" || PASSWORD == ""  { 
-		panic("Mail server username/password cannot be empty")
+	if USERNAME == "" || PASSWORD == "" || HOST == "" || PORT == "" || FROM == "" { 
+		panic("Mail server USERNAME/PASSWORD/HOST/PORT/FROM cannot be empty")
 	} 
+	
+	
+	intValue, err := strconv.Atoi(PORT)
+	if err != nil {
+		panic("Mail server PORT value is invalid")
+	} else {
+		IPORT = intValue
+	}
 }
 
 func main() {

--- a/src/server.go
+++ b/src/server.go
@@ -46,7 +46,7 @@ func handleMail(w http.ResponseWriter, r *http.Request) {
 	sendMail(req)
 
 	response := Response{}
-	response.Message = "Email has been successfully to " + req.Email
+	response.Message = "Email has been successfully send to " + req.Email
 	
 	output, err := json.Marshal(response)
 	if err != nil {
@@ -65,9 +65,6 @@ func sendMail(req IncomingReq) {
 	msg.SetHeader("Subject", req.Subject)
 	msg.SetBody("text/html", "<b>" + req.Body + "</b>!")
 
-	//host := "smtp.mailtrap.io"
-	//port := 2525
-	
 	daemon := gomail.NewDialer(HOST, IPORT, USERNAME, PASSWORD)
 
 	// Send the email


### PR DESCRIPTION
Linking with issue #7 

- Parameterize `HOST`, `PORT` & `FROM`
- Updated response message
- Added Validation for `PORT` & other fields

**Example:**
`USERNAME=<Test> PASSWORD=<Test>  HOST=<Test> PORT=<Test>  FROM=<Test>   go run server.go`

@rishinair11 